### PR TITLE
Data descriptor parsing support

### DIFF
--- a/src/main/java/blue/endless/jarvibecheck/JarVibeCheck.java
+++ b/src/main/java/blue/endless/jarvibecheck/JarVibeCheck.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import blue.endless.jarvibecheck.impl.LocalFileHeader;
 import blue.endless.jarvibecheck.impl.ZipFlags;
 import blue.endless.jarvibecheck.impl.CentralDirectoryFile;
+import blue.endless.jarvibecheck.impl.CompressionMethod;
 import blue.endless.jarvibecheck.impl.DataDescriptor;
 import blue.endless.jarvibecheck.impl.EndOfCentralDirectory;
 import blue.endless.jarvibecheck.impl.IntelDataInputStream;
@@ -58,7 +59,7 @@ public class JarVibeCheck {
 					}
 					
 					if ((header.flags & ZipFlags.DATA_DESCRIPTOR_FOLLOWS) == ZipFlags.DATA_DESCRIPTOR_FOLLOWS) {
-						if (header.compression != 0x08) {
+						if (header.compression != CompressionMethod.DEFLATE.value()) {
 							return Optional.of("A data descriptor was used in a local file header, but the compression method wasn't deflate");
 						}
 						

--- a/src/main/java/blue/endless/jarvibecheck/JarVibeCheck.java
+++ b/src/main/java/blue/endless/jarvibecheck/JarVibeCheck.java
@@ -103,7 +103,7 @@ public class JarVibeCheck {
 						header.uncompressedSize = dataDesc.uncompressedSize;
 						
 						if (inflated != header.compressedSize) {
-							return Optional.of("Deflate compressed data size didn't amount of bytes decompressed match in a local file header");
+							return Optional.of("Deflate compressed data size didn't match amount of bytes decompressed in a local file header");
 						}
 					} else {
 						din.skip((int) header.compressedSize);

--- a/src/main/java/blue/endless/jarvibecheck/JarVibeCheck.java
+++ b/src/main/java/blue/endless/jarvibecheck/JarVibeCheck.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 import blue.endless.jarvibecheck.impl.LocalFileHeader;
+import blue.endless.jarvibecheck.impl.ZipFlags;
 import blue.endless.jarvibecheck.impl.CentralDirectoryFile;
 import blue.endless.jarvibecheck.impl.DataDescriptor;
 import blue.endless.jarvibecheck.impl.EndOfCentralDirectory;
@@ -56,7 +57,7 @@ public class JarVibeCheck {
 						return Optional.of("A local file header's compressed and uncompressed sizes were both zero, but the crc was set.");
 					}
 					
-					if ((header.flags & 8) == 8) {
+					if ((header.flags & ZipFlags.DATA_DESCRIPTOR_FOLLOWS) == ZipFlags.DATA_DESCRIPTOR_FOLLOWS) {
 						if (header.compression != 0x08) {
 							return Optional.of("A data descriptor was used in a local file header, but the compression method wasn't deflate");
 						}

--- a/src/main/java/blue/endless/jarvibecheck/impl/DataDescriptor.java
+++ b/src/main/java/blue/endless/jarvibecheck/impl/DataDescriptor.java
@@ -1,7 +1,25 @@
 package blue.endless.jarvibecheck.impl;
 
+import java.io.IOException;
+
 public class DataDescriptor {
-	int crc32; //4 bytes
-	int compressedSize; //4 bytes
-	int uncompressedSize; //4 bytes
+	public static final int SIGNATURE = 0x08074b50;
+	
+	public int crc32; //4 bytes
+	public int compressedSize; //4 bytes
+	public int uncompressedSize; //4 bytes
+	
+	public static DataDescriptor read(IntelDataInputStream in) throws IOException {
+		DataDescriptor header = new DataDescriptor();
+		header.crc32 = (int) in.i32();
+		// The data descriptor header is optional
+		if (header.crc32 == DataDescriptor.SIGNATURE) {
+			header.crc32 = (int) in.i32();
+		}
+		
+		header.compressedSize = (int) in.i32();
+		header.uncompressedSize = (int) in.i32();
+		
+		return header;
+	}
 }

--- a/src/main/java/blue/endless/jarvibecheck/impl/DataDescriptor.java
+++ b/src/main/java/blue/endless/jarvibecheck/impl/DataDescriptor.java
@@ -5,20 +5,20 @@ import java.io.IOException;
 public class DataDescriptor {
 	public static final int SIGNATURE = 0x08074b50;
 	
-	public int crc32; //4 bytes
-	public int compressedSize; //4 bytes
-	public int uncompressedSize; //4 bytes
+	public long crc32; //4 bytes
+	public long compressedSize; //4 bytes
+	public long uncompressedSize; //4 bytes
 	
 	public static DataDescriptor read(IntelDataInputStream in) throws IOException {
 		DataDescriptor header = new DataDescriptor();
-		header.crc32 = (int) in.i32();
+		header.crc32 = in.i32();
 		// The data descriptor header is optional
 		if (header.crc32 == DataDescriptor.SIGNATURE) {
-			header.crc32 = (int) in.i32();
+			header.crc32 = in.i32();
 		}
 		
-		header.compressedSize = (int) in.i32();
-		header.uncompressedSize = (int) in.i32();
+		header.compressedSize = in.i32();
+		header.uncompressedSize = in.i32();
 		
 		return header;
 	}


### PR DESCRIPTION
For local file entires which use a data descriptor, this reads compressed input until the end of the deflate stream is reached, then reads the data descriptor. Includes various checks for error conditions. Tested on modmenu and the Forge installer.